### PR TITLE
fix test as CM now parses line as a header

### DIFF
--- a/test/fixtures/mark.txt
+++ b/test/fixtures/mark.txt
@@ -102,9 +102,8 @@ test
 == a</p>
 <p>==
 test==</p>
-<p>==
-test
-==</p>
+<h1>==
+test</h1>
 .
 
 


### PR DESCRIPTION
CommonMark recognizes 

```
==
test
==
```

as a header.  https://spec.commonmark.org/dingus/?text=%3D%3D%0Atest%0A%3D%3D%0A

Fixed the fixture so tests now pass.